### PR TITLE
Add missing dependency

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -30,7 +30,7 @@ To get the attack tools and experiment scripts to work, you'll need to install
 all of this stuff first:
 
 ```
-# apt-get install build-essential libelf-dev ruby
+# apt-get install build-essential libelf-dev ruby rsync
 ```
 
 And the ruby gems:


### PR DESCRIPTION
rsync was not installed on my machine; `./experiment.sh` failed due to this.

**Note:** I use a non-Debian distro, but I don't think e.g. `build-essential` ships `rsync`.